### PR TITLE
fix really annoying missing case warning (from gcc)

### DIFF
--- a/src/kowhai_serialize.c
+++ b/src/kowhai_serialize.c
@@ -638,6 +638,8 @@ int kowhai_deserialize(char* buffer, void* scratch, int scratch_size, struct kow
         case -2:
         case -3:
             return KOW_STATUS_TARGET_BUFFER_TOO_SMALL;
+        default:
+            break;
     }
     *descriptor_size = desc_nodes_populated;
     *data_size = data_offset;


### PR DESCRIPTION
just default it to nothing so gcc wont warn
