### PR TITLE
adds a new [de]serialize method for nodes only

### DIFF
--- a/src/kowhai.h
+++ b/src/kowhai.h
@@ -83,6 +83,8 @@ union kowhai_symbol_t
 #define KOW_STATUS_NOT_FOUND               12
 #define KOW_STATUS_INVALID_SEQUENCE        13
 #define KOW_STATUS_NO_DATA                 14
+#define KOW_STATUS_PATH_TOO_SMALL          15
+#define KOW_STATUS_UNKNOWN_ERROR           16
 
 /**
  * @brief return the version of the kowhai library

--- a/src/kowhai_serialize.c
+++ b/src/kowhai_serialize.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #define NAME "name"
 #define TYPE "type"
@@ -462,25 +463,25 @@ int val_to_str(struct kowhai_node_t *node, void *data, char *dst, int dst_len)
         {
             case KOW_CHAR:
                 ///@todo handle this better so it looks like a proper string !
-                r = snprintf(dst, dst_len, "%i", val.c);
+                r = snprintf(dst, dst_len, "%"PRIi8, (uint8_t)val.c);
                 break;
             case KOW_INT8:
-                r = snprintf(dst, dst_len, "%i", val.i8);
+                r = snprintf(dst, dst_len, "%"PRIi8, val.i8);
                 break;
             case KOW_INT16:
-                r = snprintf(dst, dst_len, "%i", val.i16);
+                r = snprintf(dst, dst_len, "%"PRIi16, val.i16);
                 break;
             case KOW_INT32:
-                r = snprintf(dst, dst_len, "%i", val.i32);
+                r = snprintf(dst, dst_len, "%"PRIi32, val.i32);
                 break;
             case KOW_UINT8:
-                r = snprintf(dst, dst_len, "%u", val.ui8);
+                r = snprintf(dst, dst_len, "%"PRIu8, val.ui8);
                 break;
             case KOW_UINT16:
-                r = snprintf(dst, dst_len, "%u", val.ui16);
+                r = snprintf(dst, dst_len, "%"PRIu16, val.ui16);
                 break;
             case KOW_UINT32:
-                r = snprintf(dst, dst_len, "%u", val.ui32);
+                r = snprintf(dst, dst_len, "%"PRIu32, val.ui32);
                 break;
             case KOW_FLOAT:
                 r = snprintf(dst, dst_len, "%f", val.f);

--- a/src/kowhai_serialize.c
+++ b/src/kowhai_serialize.c
@@ -404,68 +404,68 @@ static const char *strnchr(const char *str, size_t len, char c)
 
 int kowhai_str_to_path(const char *path_str, int path_strlen, union kowhai_symbol_t *path, int *path_len, void *get_name_param, kowhai_get_symbol_t get_name)
 {
-	int ipath = 0;
-	const char *init = path_str;
-	const char *sym_start = init, *sym_end;
-	const char *istart = init, *iend;
-	int r, index;
+    int ipath = 0;
+    const char *init = path_str;
+    const char *sym_start = init, *sym_end;
+    const char *istart = init, *iend;
+    int r, index;
 
-	while (sym_start < init + path_strlen)
-	{
-		// find next symbol
-		sym_end = strnchr(sym_start, path_strlen, '.');
-		if (sym_end == NULL)
-			sym_end = init + path_strlen; // so the rest of the string
+    while (sym_start < init + path_strlen)
+    {
+        // find next symbol
+        sym_end = strnchr(sym_start, path_strlen, '.');
+        if (sym_end == NULL)
+            sym_end = init + path_strlen; // so the rest of the string
 
-		// check for index
-		index = 0;
-		istart = strnchr(sym_start, sym_end - sym_start, '[');
-		iend = strnchr(sym_start, sym_end - sym_start, ']');
-		if (istart != NULL)
-		{
-			if (iend == NULL)
-				return KOW_STATUS_INVALID_SYMBOL_PATH; // malformed path, array index start must have a end
-			index = atoi(istart + 1);
-		}
-		else
-			istart = sym_end; // if no indexing this starts (and ends) at the last char
+        // check for index
+        index = 0;
+        istart = strnchr(sym_start, sym_end - sym_start, '[');
+        iend = strnchr(sym_start, sym_end - sym_start, ']');
+        if (istart != NULL)
+        {
+            if (iend == NULL)
+                return KOW_STATUS_INVALID_SYMBOL_PATH; // malformed path, array index start must have a end
+            index = atoi(istart + 1);
+        }
+        else
+            istart = sym_end; // if no indexing this starts (and ends) at the last char
 
-		r = get_name(get_name_param, sym_start, istart - sym_start);
-		if (r < 0)
-			return KOW_STATUS_NOT_FOUND;
-		path[ipath++].symbol = KOWHAI_SYMBOL(r, index);
-		if (ipath >= *path_len)
-			return KOW_STATUS_PATH_TOO_SMALL; // path buffer not big enough
+        r = get_name(get_name_param, sym_start, istart - sym_start);
+        if (r < 0)
+            return KOW_STATUS_NOT_FOUND;
+        path[ipath++].symbol = KOWHAI_SYMBOL(r, index);
+        if (ipath >= *path_len)
+            return KOW_STATUS_PATH_TOO_SMALL; // path buffer not big enough
 
-		sym_start = sym_end + 1;
-	}
+        sym_start = sym_end + 1;
+    }
 
-	// return number of symbols in the path
-	*path_len = ipath;
-	return KOW_STATUS_OK;
+    // return number of symbols in the path
+    *path_len = ipath;
+    return KOW_STATUS_OK;
 }
 
 // internal helper function to avoid return type conflicts with the kowhai method
 static int str_to_path(jsmn_parser* parser, jsmntok_t* tok, union kowhai_symbol_t *path, int path_len, void *get_name_param, kowhai_get_symbol_t get_name)
 {
-	const char *path_str = &parser->js[tok->start];
-	int path_strlen = tok->end - tok->start;
-	int e;
+    const char *path_str = &parser->js[tok->start];
+    int path_strlen = tok->end - tok->start;
+    int e;
 
-	e = kowhai_str_to_path(path_str, path_strlen, path, &path_len, get_name_param, get_name);
-	switch (e)
-	{
-		case KOW_STATUS_INVALID_SYMBOL_PATH:
-			return -2;
-		case KOW_STATUS_NOT_FOUND:
-			return -4;
-		case KOW_STATUS_PATH_TOO_SMALL:
-			return -3;
-		case KOW_STATUS_OK:
-			return path_len;
-		default:
-			return KOW_STATUS_UNKNOWN_ERROR;
-	}
+    e = kowhai_str_to_path(path_str, path_strlen, path, &path_len, get_name_param, get_name);
+    switch (e)
+    {
+        case KOW_STATUS_INVALID_SYMBOL_PATH:
+            return -2;
+        case KOW_STATUS_NOT_FOUND:
+            return -4;
+        case KOW_STATUS_PATH_TOO_SMALL:
+            return -3;
+        case KOW_STATUS_OK:
+            return path_len;
+        default:
+            return KOW_STATUS_UNKNOWN_ERROR;
+    }
 }
 
 static int val_to_str(struct kowhai_node_t *node, void *data, char *dst, int dst_len)

--- a/src/kowhai_serialize.h
+++ b/src/kowhai_serialize.h
@@ -28,6 +28,18 @@ typedef int (*kowhai_get_symbol_t)(void* param, const char *symbol, int len);
 typedef int (*kowhai_node_not_found_t)(void* param, union kowhai_symbol_t *path, int path_len);
 
 /**
+ * @brief convert a string with symbol names separated by '.' delimiters and arrays '[]' into a kowhai_symbol_t array
+ * @param path_str path string to convert (symbols should be separated by '.' chars and array index designated by '[2]' for example, 0 is assumed if index not present
+ * @param path_strlen number of chars in the above string
+ * @param path destination populated with kowhai_symbol_t to make the path
+ * @param path_len size of path (number of kowhai_symbol_t allocated), updated on KOW_STATUS_OK to the number of symbols populated
+ * @param get_name_param passed to the callback below
+ * @param get_name called supplied callback, given a symbol string it returns the symbol ID
+ * @return standard kowhai returns (ie KOW_STATUS_OK on success, else error)
+ */
+int kowhai_str_to_path(const char *path_str, int path_strlen, union kowhai_symbol_t *path, int *path_len, void *get_name_param, kowhai_get_symbol_t get_name);
+
+/**
  * Convert a kowhai tree to a json ascii string
  *
  * @param tree, the kowhai tree

--- a/tools/test.c
+++ b/tools/test.c
@@ -243,6 +243,7 @@ struct scope_data_t
 //
 
 struct settings_data_t settings;
+struct settings_data_t settings2;
 struct kowhai_tree_t settings_tree = {settings_descriptor, &settings};
 struct shadow_data_t shadow;
 struct kowhai_tree_t shadow_tree = {shadow_descriptor, &shadow};
@@ -466,6 +467,22 @@ char* get_symbol_name(void* param, uint16_t symbol)
     return symbols[symbol];
 }
 
+int get_symbol_index(void *param, const char *symbol, int len)
+{
+    int i;
+    for (i = 0; i < COUNT_OF(symbols); i++)
+    {
+        if (strncmp(symbols[i], symbol, len) == 0 && strlen(symbols[i]) == len)
+            return i;
+    }
+    return -1;
+}
+
+int ignore_missing_nodes(void* param, union kowhai_symbol_t *path, int path_len)
+{
+    return 0;
+}
+
 void serialization_tests()
 {
 #define BUF_SIZE 0x3000
@@ -473,35 +490,69 @@ void serialization_tests()
     int desc_size = BUF_SIZE;
     int data_size = BUF_SIZE;
     char* js = (char*)malloc(BUF_SIZE);
+    char* badjs = (char*)malloc(BUF_SIZE);
     char* scratch = (char*)malloc(BUF_SIZE);
     struct kowhai_node_t* desc = (struct kowhai_node_t*)malloc(BUF_SIZE);
     char* data = (char*)malloc(BUF_SIZE);
+    union kowhai_symbol_t path[32];
+    int n;
 
     printf("test kowhai_serialize/kowhai_deserialize...\n");
 
-    // kowhai_serialize
+    // kowhai_serialize (tree)
     assert(js != NULL && scratch != NULL && desc != NULL && data != NULL);
     buf_size = 100;
-    assert(kowhai_serialize(settings_tree, js, &buf_size, NULL, get_symbol_name) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
+    assert(kowhai_serialize_tree(settings_tree, js, &buf_size, NULL, get_symbol_name) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
     buf_size = BUF_SIZE;
-    assert(kowhai_serialize(settings_tree, js, &buf_size, NULL, get_symbol_name) == KOW_STATUS_OK);
+    assert(kowhai_serialize_tree(settings_tree, js, &buf_size, NULL, get_symbol_name) == KOW_STATUS_OK);
     printf("---\n%s\n***\n", js);
-    printf("js length: %d\n", strlen(js));
+    printf("js length: %d\n", (int)strlen(js));
     printf("---\n");
-    // kowhai_deserialize
+    
+    // kowhai_deserialize (tree)
     buf_size = BUF_SIZE;
     desc_size = 10;
     data_size = 10;
-    assert(kowhai_deserialize(js, scratch, 100, desc, &desc_size, data, &data_size) == KOW_STATUS_SCRATCH_TOO_SMALL);
-    assert(kowhai_deserialize(js, scratch, buf_size, desc, &desc_size, data, &data_size) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
+    assert(kowhai_deserialize_tree(js, scratch, 100, desc, &desc_size, data, &data_size) == KOW_STATUS_SCRATCH_TOO_SMALL);
+    assert(kowhai_deserialize_tree(js, scratch, buf_size, desc, &desc_size, data, &data_size) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
     desc_size = buf_size / sizeof(struct kowhai_node_t);
-    assert(kowhai_deserialize(js, scratch, buf_size, desc, &desc_size, data, &data_size) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
+    assert(kowhai_deserialize_tree(js, scratch, buf_size, desc, &desc_size, data, &data_size) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
     data_size = buf_size;
-    assert(kowhai_deserialize(js, scratch, buf_size, desc, &desc_size, data, &data_size) == KOW_STATUS_OK);
+    assert(kowhai_deserialize_tree(js, scratch, buf_size, desc, &desc_size, data, &data_size) == KOW_STATUS_OK);
     assert(desc_size == sizeof(settings_descriptor) / sizeof(struct kowhai_node_t));
     assert(memcmp(desc, settings_descriptor, sizeof(settings_descriptor)) == 0);
     assert(data_size == sizeof(settings));
     assert(memcmp(data, &settings, sizeof(settings)) == 0);
+
+    // kowhai serialize (nodes)
+    buf_size = 10; // test dst buffer too small
+    assert(kowhai_serialize_nodes(js, &buf_size, &settings_tree, path, COUNT_OF(path), NULL, get_symbol_name) == KOW_STATUS_TARGET_BUFFER_TOO_SMALL);
+    buf_size = BUF_SIZE; // test path too small
+    assert(kowhai_serialize_nodes(js, &buf_size, &settings_tree, path, 3, NULL, get_symbol_name) == KOW_STATUS_PATH_TOO_SMALL);
+    assert(kowhai_serialize_nodes(js, &buf_size, &settings_tree, path, COUNT_OF(path), NULL, get_symbol_name) == KOW_STATUS_OK);
+    printf("---\n%s\n***\n", js);
+    printf("js length: %d\n", (int)strlen(js));
+    printf("---\n");
+
+    // kowhai deserialize (nodes)
+    n = sprintf(badjs, "{\"path\": \"Settings.Oven.Gain\", \"type\": 114, \"count\": 1, \"tag\": 0, \"value\": 999}\n"); // test a path that does not exist in the dst_tree
+    assert(kowhai_deserialize_nodes(badjs, n, &settings_tree, path, COUNT_OF(path), scratch, BUF_SIZE, NULL, get_symbol_index, NULL, NULL) == KOW_STATUS_INVALID_SYMBOL_PATH);
+    n = sprintf(badjs, "{\"path\": \"Settings.Oven.Gain\", \"type\": 114, \"count\": 1, \"tag\": 0, \"value\": 999}\n"); // test a path that does not exist in the dst_tree, but ignore the error
+    assert(kowhai_deserialize_nodes(badjs, n, &settings_tree, path, COUNT_OF(path), scratch, BUF_SIZE, NULL, get_symbol_index, NULL, ignore_missing_nodes) == KOW_STATUS_OK);
+    n = sprintf(badjs, "{\"path\": \"Settings.Oven.Gain[5\", \"type\": 114, \"count\": 1, \"tag\": 0, \"value\": 999}\n"); // test a mangled path
+    assert(kowhai_deserialize_nodes(badjs, n, &settings_tree, path, COUNT_OF(path), scratch, BUF_SIZE, NULL, get_symbol_index, NULL, NULL) == KOW_STATUS_INVALID_SYMBOL_PATH);
+    n = sprintf(badjs, "{\"path\": \"Settings.Oven.Moo\", \"type\": 114, \"count\": 1, \"tag\": 0, \"value\": 999}\n"); // test a symbol that we dont know
+    assert(kowhai_deserialize_nodes(badjs, n, &settings_tree, path, COUNT_OF(path), scratch, BUF_SIZE, NULL, get_symbol_index, NULL, NULL) == KOW_STATUS_NOT_FOUND);
+    assert(kowhai_deserialize_nodes(js, buf_size, &settings_tree, path, 3, scratch, BUF_SIZE, NULL, get_symbol_index, NULL, NULL) == KOW_STATUS_PATH_TOO_SMALL);
+    assert(kowhai_deserialize_nodes(js, buf_size, &settings_tree, path, COUNT_OF(path), scratch, 1, NULL, get_symbol_index, NULL, NULL) == KOW_STATUS_SCRATCH_TOO_SMALL);
+    settings2 = settings;
+    memset(&settings, 0, sizeof(settings));
+    assert(kowhai_deserialize_nodes(js, buf_size, &settings_tree, path, COUNT_OF(path), scratch, BUF_SIZE, NULL, get_symbol_index, NULL, NULL) == KOW_STATUS_OK);
+    assert(settings.flux_capacitor[0].frequency == settings2.flux_capacitor[0].frequency);
+    assert(settings.flux_capacitor[FLUX_CAP_COUNT - 1].coefficient[COEFF_COUNT - 1] == settings2.flux_capacitor[FLUX_CAP_COUNT - 1].coefficient[COEFF_COUNT - 1]);
+    assert(settings.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].beep == settings2.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].beep);
+    assert(memcmp(settings.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].owner, settings2.union_container[UNION_COUNT - 1].union_[UNION_COUNT - 1].owner, OWNER_MAX_LEN) == 0);
+    assert(settings.check == settings2.check);
 
     printf(" passed!\n");
 }


### PR DESCRIPTION
summary of changes:
- add kowhai_[de]serialize_nodes() to serialise the tree in a flat
  jason file where the tree path is encoded in a string .. this is
  more useful for editing by hand in a file, or if you just want to
  write part of a tree, ie writing every instance of bar in foo, but
  only bar not the other surrounding elements of foo, ie:
  element:
      struct
      {
          int untouched1;
          int bar;
          int untouched2;
      } foo[4];
  note that this api does not rebuild a kowhai_tree from scratch given
  the serialised file, instead it merges the data it has into an
  existing tree with a similar structure (see kowahi_node_not_found_t
  callback for merging options) .. also it _requires_ (cannot be NULL)
  as kowahi_get_symbol_t callback to convert a symbol string to a node
  id and a kowahi_get_symbol_name_t (like the tree api) ... if human
  readable symbol strings are not used you can just printf and scanf
  the numbers into the tree, if symbol names are used they must not
  include '.' or '[' or ']' characters (these are special delimiters
  in path encoding.
- renamed kowhai_[de]serialize() -> kowhai_[de]serialize_tree() ...
  functionality remains unchanged (done just to make clear what type
  of serialization is being performed, ie not nodes)
- add new error types for new api's
- replace a union type for all kowhai type that was being redefined
  over and over with a named union called anytype_t
- unit test updated for api name changes and cover all foreseeable
  error conditions on new kowhai_[de]serialize() api, and of course
  the successful condition of serializing and de-serializing a kowahi
  tee's nodes is done
