### PR TITLE
fix buffer overrun in [kowhai_]serialize_nodes

### DIFF
--- a/src/kowhai_serialize.c
+++ b/src/kowhai_serialize.c
@@ -686,6 +686,8 @@ static int serialize_nodes(struct kowhai_node_t *root, char *dst, int dst_len, s
                     r = serialize_nodes(root, dst, dst_len, node + 1, src_data, path, ipath + 1, path_len, get_name_param, get_name, 1, level + 1);
                     if (r < 0)
                         return r;
+                    if (r >= dst_len)
+                        return count + r;
                 }
                 
                 // union type over
@@ -726,6 +728,8 @@ static int serialize_nodes(struct kowhai_node_t *root, char *dst, int dst_len, s
                         r = serialize_nodes(root, dst, dst_len, node + 1, src_data, path, ipath + 1, path_len, get_name_param, get_name, 0, level + 1);
                         if (r < 0)
                             return r;
+                        if (r >= dst_len)
+                            return count + r;
                         rmax = r;
 
                         // push pointer on if this is not a union


### PR DESCRIPTION
we were not always checking if a recursive call went off the end of the
buffer and since snprintf uses a size_t which is assumed to be unsigned
it thinks the buffer is huge and writes the next line (over running the
buffer), following the overrun our "if (r > dst_len)" knows we did
something wrong, but the damage is done ... this can continue in a loop
over array items which will really screw the memory after the buffer
